### PR TITLE
Create insurer model

### DIFF
--- a/app/models/insurer.rb
+++ b/app/models/insurer.rb
@@ -1,0 +1,2 @@
+class Insurer < ApplicationRecord
+end

--- a/app/models/insurer.rb
+++ b/app/models/insurer.rb
@@ -1,2 +1,4 @@
 class Insurer < ApplicationRecord
+  validates :name, presence: true
+  validates :jurisdiction, presence: true
 end

--- a/db/migrate/20251006190609_create_insurers.rb
+++ b/db/migrate/20251006190609_create_insurers.rb
@@ -1,0 +1,10 @@
+class CreateInsurers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :insurers do |t|
+      t.string :name
+      t.string :jurisdiction
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_04_201223) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_06_190609) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "insurers", force: :cascade do |t|
+    t.string "name"
+    t.string "jurisdiction"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/spec/factories/insurers.rb
+++ b/spec/factories/insurers.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :insurer do
+    name { "MyString" }
+    jurisdiction { "MyString" }
+  end
+end

--- a/spec/helpers/static_pages_helper_spec.rb
+++ b/spec/helpers/static_pages_helper_spec.rb
@@ -11,5 +11,4 @@ require 'rails_helper'
 #   end
 # end
 RSpec.describe StaticPagesHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/insurer_spec.rb
+++ b/spec/models/insurer_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Insurer, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/insurer_spec.rb
+++ b/spec/models/insurer_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Insurer, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  subject(:insurer) { create(:insurer) }
+
+  it { expect(insurer).to validate_presence_of :name }
+  it { expect(insurer).to validate_presence_of :jurisdiction }
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,8 +30,7 @@ end
 # of increasing the boot-up time by auto-requiring all files in the support
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
-#
-# Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 
 # Ensures that the test database schema matches the current schema file.
 # If there are pending migrations it will invoke `db:test:prepare` to

--- a/spec/views/static_pages/home.html.erb_spec.rb
+++ b/spec/views/static_pages/home.html.erb_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe "static_pages/home.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
Because: The app needs to represent an insurer

This commit:
- Create insurer model
- Add tests to validate insurer attributes

The Insurer model has Name and Jurisdiction attributes.