### PR TITLE
Create plan model

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-local ruby 3.4.6
+ruby 3.4.6

--- a/app/models/insurer.rb
+++ b/app/models/insurer.rb
@@ -1,4 +1,6 @@
 class Insurer < ApplicationRecord
+  has_many :plans, dependent: :destroy
+
   validates :name, presence: true
   validates :jurisdiction, presence: true
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,0 +1,12 @@
+class Plan < ApplicationRecord
+  belongs_to :insurer
+
+  validates :name, presence: true
+  validates :min_age, presence: true, numericality: { greater_than_or_equal_to: 0, only_integer: true }
+  validates :max_age, numericality: { greater_than_or_equal_to: 0, only_integer: true, allow_nil: true }
+  validates_inclusion_of :children_only_allowed, in: [ true, false ]
+  validates_inclusion_of :published, in: [ true, false ]
+  validates :version_year, presence: true
+  validates :policy_type, presence: true
+  validates :next_review_due, presence: true
+end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -9,4 +9,10 @@ class Plan < ApplicationRecord
   validates :version_year, presence: true
   validates :policy_type, presence: true
   validates :next_review_due, presence: true
+
+  enum :policy_type, {
+    individual: 0,
+    company: 1,
+    corporate: 2
+  }
 end

--- a/db/migrate/20251006201022_create_plans.rb
+++ b/db/migrate/20251006201022_create_plans.rb
@@ -1,0 +1,19 @@
+class CreatePlans < ActiveRecord::Migration[8.0]
+  def change
+    create_table :plans do |t|
+      t.references :insurer, null: false, foreign_key: true
+      t.string :name, null: false
+      t.integer :min_age, null: false, default: 0
+      t.integer :max_age
+      t.boolean :children_only_allowed, null: false, default: false
+      t.integer :version_year, null: false
+      t.boolean :published, null: false, default: false
+      t.integer :policy_type, null: false
+      t.date :last_reviewed_at
+      t.date :next_review_due, null: false
+      t.text :review_notes
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_06_190609) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_06_201022) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -19,6 +19,23 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_06_190609) do
     t.string "jurisdiction"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "plans", force: :cascade do |t|
+    t.bigint "insurer_id", null: false
+    t.string "name", null: false
+    t.integer "min_age", default: 0, null: false
+    t.integer "max_age"
+    t.boolean "children_only_allowed", default: false, null: false
+    t.integer "version_year", null: false
+    t.boolean "published", default: false, null: false
+    t.integer "policy_type", null: false
+    t.date "last_reviewed_at"
+    t.date "next_review_due", null: false
+    t.text "review_notes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["insurer_id"], name: "index_plans_on_insurer_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -43,4 +60,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_06_190609) do
     t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "plans", "insurers"
 end

--- a/spec/factories/plans.rb
+++ b/spec/factories/plans.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :plan do
+    insurer
+    name { "MyString" }
+    min_age { 1 }
+    max_age { 1 }
+    children_only_allowed { false }
+    version_year { 1 }
+    published { false }
+    policy_type { 1 }
+    last_reviewed_at { "2025-10-06" }
+    next_review_due { "2025-10-06" }
+    review_notes { "MyText" }
+  end
+end

--- a/spec/models/insurer_spec.rb
+++ b/spec/models/insurer_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Insurer, type: :model do
   subject(:insurer) { create(:insurer) }
 
+  it { expect(insurer).to have_many(:plans).dependent(:destroy) }
   it { expect(insurer).to validate_presence_of :name }
   it { expect(insurer).to validate_presence_of :jurisdiction }
 end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -11,4 +11,5 @@ RSpec.describe Plan, type: :model do
   it { expect(plan).to validate_presence_of :policy_type }
   it { expect(plan).to validate_presence_of :next_review_due  }
   it { expect(plan).to belong_to :insurer }
+  it { should define_enum_for(:policy_type).with_values(individual: 0, company: 1, corporate: 2) }
 end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Plan, type: :model do
+  subject(:plan) { create(:plan) }
+
+  it { expect(plan).to validate_presence_of :name }
+  it { expect(plan).to validate_presence_of :min_age }
+  it { expect(plan).to validate_numericality_of(:min_age).is_greater_than_or_equal_to(0).only_integer }
+  it { expect(plan).to validate_numericality_of(:max_age).is_greater_than_or_equal_to(0).only_integer.allow_nil }
+  it { expect(plan).to validate_presence_of :version_year }
+  it { expect(plan).to validate_presence_of :policy_type }
+  it { expect(plan).to validate_presence_of :next_review_due  }
+  it { expect(plan).to belong_to :insurer }
+end


### PR DESCRIPTION
Because: The health insurance comparison requires Plans to be modelled

This commit:
- Create Plan model
- Add plan model validations
- Add insurer has_many link to plans and relevant test
- Add enum for policy_type on Plan Model