### PR TITLE
Implement base-vs-enhancement ModuleBenefit behavior with ownership-preserving comparison rendering

### DIFF
--- a/app/flows/plan_wizard_flow.rb
+++ b/app/flows/plan_wizard_flow.rb
@@ -535,6 +535,7 @@ class PlanWizardFlow
       :coverage_description,
       :waiting_period_months,
       :interaction_type,
+      :base_module_benefit_id,
       :weighting,
       benefit_limit_rules_attributes: [
         :id,

--- a/app/models/module_benefit.rb
+++ b/app/models/module_benefit.rb
@@ -3,6 +3,11 @@ class ModuleBenefit < ApplicationRecord
   belongs_to :plan_module
   belongs_to :benefit
   belongs_to :benefit_limit_group, optional: true
+  belongs_to :base_module_benefit, class_name: "ModuleBenefit", optional: true
+  has_many :enhancing_module_benefits,
+           class_name: "ModuleBenefit",
+           foreign_key: :base_module_benefit_id,
+           dependent: :nullify
 
   # ModuleBenefit does not store numeric limits.
   # All numeric limits are represented via BenefitLimitRule.
@@ -21,12 +26,16 @@ class ModuleBenefit < ApplicationRecord
   validates :benefit, presence: true
   validates :plan_module, presence: true
   validates :weighting, numericality: { only_integer: true }
+  validates :base_module_benefit, presence: true, if: :enhance?
   validate :coverage_or_limit_must_be_present
+  validate :base_module_benefit_cannot_reference_self
+  validate :base_module_benefit_must_be_compatible
 
   #== Enums ======================================================
   enum :interaction_type, {
     replace: 0,
-    append: 1
+    append: 1,
+    enhance: 2
   }
 
   delegate :coverage_category, to: :benefit
@@ -52,6 +61,29 @@ class ModuleBenefit < ApplicationRecord
   def coverage_or_limit_must_be_present
     if coverage_description.blank? && benefit_limit_rules.reject(&:marked_for_destruction?).blank?
       errors.add(:base, "Either a coverage description or at least one benefit limit rule must be present")
+    end
+  end
+
+  def base_module_benefit_cannot_reference_self
+    return if base_module_benefit_id.blank?
+    return unless id.present? && base_module_benefit_id == id
+
+    errors.add(:base_module_benefit, "cannot reference itself")
+  end
+
+  def base_module_benefit_must_be_compatible
+    return if base_module_benefit.blank?
+
+    if base_module_benefit.base_module_benefit_id.present?
+      errors.add(:base_module_benefit, "must reference a base module benefit")
+    end
+
+    if benefit_id.present? && base_module_benefit.benefit_id != benefit_id
+      errors.add(:base_module_benefit, "must reference the same benefit")
+    end
+
+    if plan_module.present? && base_module_benefit.plan_module.plan_version_id != plan_module.plan_version_id
+      errors.add(:base_module_benefit, "must belong to the same plan version")
     end
   end
 end

--- a/app/models/module_benefit.rb
+++ b/app/models/module_benefit.rb
@@ -27,6 +27,7 @@ class ModuleBenefit < ApplicationRecord
   validates :plan_module, presence: true
   validates :weighting, numericality: { only_integer: true }
   validates :base_module_benefit, presence: true, if: :enhance?
+  validates :base_module_benefit, absence: true, unless: :enhance?
   validate :coverage_or_limit_must_be_present
   validate :base_module_benefit_cannot_reference_self
   validate :base_module_benefit_must_be_compatible

--- a/app/services/comparison_builder.rb
+++ b/app/services/comparison_builder.rb
@@ -157,7 +157,7 @@ class ComparisonBuilder
   def selected_module_benefits_for(benefit_id, module_benefits)
     matching_module_benefits =
       Array(module_benefits)
-        .select { |module_benefit| module_benefit.benefit_id == benefit_id && !module_benefit.enhance? && module_benefit.base_module_benefit_id.blank? }
+        .select { |module_benefit| module_benefit.benefit_id == benefit_id && !module_benefit.enhance? }
         .sort_by { |module_benefit| [ module_benefit.weighting, module_benefit.created_at ] }
 
     replace_module_benefits = matching_module_benefits.select(&:replace?)

--- a/app/services/comparison_builder.rb
+++ b/app/services/comparison_builder.rb
@@ -10,7 +10,27 @@ class ComparisonBuilder
     return empty_payload if selections.empty?
 
     plans_by_id =
-      Plan.includes(:insurer, current_plan_version: { plan_modules: { module_benefits: [ :benefit, { benefit_limit_group: :benefit_limit_group_rules }, :cost_shares, { benefit_limit_rules: :cost_share } ] } })
+      Plan.includes(
+        :insurer,
+        current_plan_version: {
+          plan_modules: {
+            module_benefits: [
+              :benefit,
+              { benefit_limit_group: :benefit_limit_group_rules },
+              :cost_shares,
+              { benefit_limit_rules: :cost_share },
+              {
+                enhancing_module_benefits: [
+                  :plan_module,
+                  :cost_shares,
+                  { benefit_limit_group: :benefit_limit_group_rules },
+                  { benefit_limit_rules: :cost_share }
+                ]
+              }
+            ]
+          }
+        }
+      )
         .where(id: selections.map { |selection| selection["plan_id"] }.compact)
         .index_by(&:id)
 
@@ -79,16 +99,21 @@ class ComparisonBuilder
     selected_module_benefits = selected_module_benefits_for(benefit_id, module_benefits)
 
     selected_module_benefits.map do |module_benefit|
+      enhancements = applicable_enhancements_for(module_benefit, module_benefits)
+      effective_benefit_limit_rules = effective_benefit_limit_rules_for(module_benefit, enhancements)
+      benefit_level_rules, itemised_rules = effective_benefit_limit_rules.partition(&:benefit_level?)
+      effective_cost_share_owner = effective_cost_share_owner_for(module_benefit, enhancements)
+
         {
           module_benefit_id: module_benefit.id,
           plan_module_id: module_benefit.plan_module_id,
           plan_module_name: module_benefit.plan_module.name,
           coverage_description: module_benefit.coverage_description,
-          cost_share_text: cost_share_text(module_benefit),
-          benefit_level_limit_rules: module_benefit.benefit_limit_rules.benefit_level.map do |rule|
+          cost_share_text: cost_share_text(effective_cost_share_owner),
+          benefit_level_limit_rules: benefit_level_rules.map do |rule|
             {
               name: rule.name,
-              cost_share_text: rule_cost_share_text(rule, module_benefit),
+              cost_share_text: rule_cost_share_text(rule, effective_cost_share_owner),
               limit_type: rule.limit_type,
               insurer_amount_usd: rule.insurer_amount_usd,
               insurer_amount_gbp: rule.insurer_amount_gbp,
@@ -102,10 +127,10 @@ class ComparisonBuilder
               position: rule.position
             }
           end,
-          itemised_limit_rules: module_benefit.benefit_limit_rules.itemised.map do |rule|
+          itemised_limit_rules: itemised_rules.map do |rule|
             {
               name: rule.name,
-              cost_share_text: rule_cost_share_text(rule, module_benefit),
+              cost_share_text: rule_cost_share_text(rule, effective_cost_share_owner),
               limit_type: rule.limit_type,
               insurer_amount_usd: rule.insurer_amount_usd,
               insurer_amount_gbp: rule.insurer_amount_gbp,
@@ -119,24 +144,58 @@ class ComparisonBuilder
               position: rule.position
             }
           end,
-          waiting_period_months: module_benefit.waiting_period_months,
+          waiting_period_months: effective_waiting_period_months_for(module_benefit, enhancements),
           interaction_type: module_benefit.interaction_type,
-          benefit_limit_group_name: module_benefit.benefit_limit_group&.name,
-          benefit_limit_group_rule_text: shared_limit_group_rule_text(module_benefit.benefit_limit_group)
+          benefit_limit_group_name: effective_benefit_limit_group_for(module_benefit, enhancements)&.name,
+          benefit_limit_group_rule_text: shared_limit_group_rule_text(effective_benefit_limit_group_for(module_benefit, enhancements)),
+          enhancement_notes: enhancement_notes_for(enhancements),
+          enhanced_by_module_names: enhancements.map { |enhancement| enhancement.plan_module.name }.uniq
         }
-      end
+    end
   end
 
   def selected_module_benefits_for(benefit_id, module_benefits)
     matching_module_benefits =
       Array(module_benefits)
-        .select { |module_benefit| module_benefit.benefit_id == benefit_id }
+        .select { |module_benefit| module_benefit.benefit_id == benefit_id && !module_benefit.enhance? && module_benefit.base_module_benefit_id.blank? }
         .sort_by { |module_benefit| [ module_benefit.weighting, module_benefit.created_at ] }
 
     replace_module_benefits = matching_module_benefits.select(&:replace?)
     return matching_module_benefits if replace_module_benefits.empty?
 
     [ replace_module_benefits.max_by { |module_benefit| [ module_benefit.weighting, module_benefit.created_at ] } ]
+  end
+
+  def applicable_enhancements_for(base_module_benefit, module_benefits)
+    Array(module_benefits)
+      .select { |module_benefit| module_benefit.enhance? && module_benefit.base_module_benefit_id == base_module_benefit.id }
+      .sort_by { |module_benefit| [ module_benefit.weighting, module_benefit.created_at ] }
+  end
+
+  def effective_waiting_period_months_for(base_module_benefit, enhancements)
+    override = enhancements.reverse.find { |enhancement| enhancement.waiting_period_months.present? }
+    override&.waiting_period_months || base_module_benefit.waiting_period_months
+  end
+
+  def effective_benefit_limit_rules_for(base_module_benefit, enhancements)
+    override = enhancements.reverse.find { |enhancement| enhancement.benefit_limit_rules.any? }
+    return base_module_benefit.benefit_limit_rules unless override
+
+    override.benefit_limit_rules
+  end
+
+  def effective_cost_share_owner_for(base_module_benefit, enhancements)
+    override = enhancements.reverse.find { |enhancement| enhancement.cost_shares.any? }
+    override || base_module_benefit
+  end
+
+  def effective_benefit_limit_group_for(base_module_benefit, enhancements)
+    override = enhancements.reverse.find { |enhancement| enhancement.benefit_limit_group.present? }
+    override&.benefit_limit_group || base_module_benefit.benefit_limit_group
+  end
+
+  def enhancement_notes_for(enhancements)
+    enhancements.filter_map(&:coverage_description)
   end
 
   def empty_payload

--- a/app/services/comparison_exports/benefits_xlsx.rb
+++ b/app/services/comparison_exports/benefits_xlsx.rb
@@ -42,6 +42,12 @@ module ComparisonExports
       lines = []
       lines << entry[:plan_module_name].to_s if entry[:plan_module_name].present?
       lines << entry[:coverage_description].to_s if entry[:coverage_description].present?
+      if entry[:enhanced_by_module_names].present?
+        lines << "Enhanced by #{Array(entry[:enhanced_by_module_names]).to_sentence}"
+      end
+      Array(entry[:enhancement_notes]).each do |note|
+        lines << note
+      end
 
       benefit_level_rules = entry[:benefit_level_limit_rules].to_a
       lines << entry[:cost_share_text] if benefit_level_rules.empty? && entry[:cost_share_text].present?

--- a/app/services/plan_version_duplicator.rb
+++ b/app/services/plan_version_duplicator.rb
@@ -86,16 +86,27 @@ class PlanVersionDuplicator
   end
 
   def copy_module_benefits(plan_module_map, benefit_limit_group_map)
-    plan_version.plan_modules.each_with_object({}) do |plan_module, map|
+    old_to_old_base_map = {}
+
+    module_benefit_map = plan_version.plan_modules.each_with_object({}) do |plan_module, map|
       new_module = plan_module_map[plan_module.id]
       plan_module.module_benefits.each do |benefit|
         new_group = benefit_limit_group_map[benefit.benefit_limit_group_id]
         new_benefit = new_module.module_benefits.create!(
-          sanitized_attributes(benefit, %w[benefit_limit_group_id]).merge(benefit_limit_group: new_group)
+          sanitized_attributes(benefit, %w[benefit_limit_group_id base_module_benefit_id]).merge(benefit_limit_group: new_group)
         )
         map[benefit.id] = new_benefit
+        old_to_old_base_map[benefit.id] = benefit.base_module_benefit_id
       end
     end
+
+    old_to_old_base_map.each do |old_benefit_id, old_base_benefit_id|
+      next if old_base_benefit_id.blank?
+
+      module_benefit_map[old_benefit_id].update!(base_module_benefit: module_benefit_map[old_base_benefit_id])
+    end
+
+    module_benefit_map
   end
 
   def copy_benefit_limit_group_rules(benefit_limit_group_map)

--- a/app/services/plan_version_duplicator.rb
+++ b/app/services/plan_version_duplicator.rb
@@ -86,24 +86,28 @@ class PlanVersionDuplicator
   end
 
   def copy_module_benefits(plan_module_map, benefit_limit_group_map)
-    old_to_old_base_map = {}
+    source_module_benefits = plan_version.plan_modules.flat_map(&:module_benefits)
+    base_module_benefits, enhancement_module_benefits = source_module_benefits.partition { |benefit| benefit.base_module_benefit_id.blank? }
 
-    module_benefit_map = plan_version.plan_modules.each_with_object({}) do |plan_module, map|
-      new_module = plan_module_map[plan_module.id]
-      plan_module.module_benefits.each do |benefit|
-        new_group = benefit_limit_group_map[benefit.benefit_limit_group_id]
-        new_benefit = new_module.module_benefits.create!(
-          sanitized_attributes(benefit, %w[benefit_limit_group_id base_module_benefit_id]).merge(benefit_limit_group: new_group)
-        )
-        map[benefit.id] = new_benefit
-        old_to_old_base_map[benefit.id] = benefit.base_module_benefit_id
-      end
+    module_benefit_map = {}
+
+    base_module_benefits.each do |benefit|
+      new_module = plan_module_map[benefit.plan_module_id]
+      new_group = benefit_limit_group_map[benefit.benefit_limit_group_id]
+      module_benefit_map[benefit.id] = new_module.module_benefits.create!(
+        sanitized_attributes(benefit, %w[benefit_limit_group_id base_module_benefit_id]).merge(benefit_limit_group: new_group)
+      )
     end
 
-    old_to_old_base_map.each do |old_benefit_id, old_base_benefit_id|
-      next if old_base_benefit_id.blank?
-
-      module_benefit_map[old_benefit_id].update!(base_module_benefit: module_benefit_map[old_base_benefit_id])
+    enhancement_module_benefits.each do |benefit|
+      new_module = plan_module_map[benefit.plan_module_id]
+      new_group = benefit_limit_group_map[benefit.benefit_limit_group_id]
+      module_benefit_map[benefit.id] = new_module.module_benefits.create!(
+        sanitized_attributes(benefit, %w[benefit_limit_group_id base_module_benefit_id]).merge(
+          benefit_limit_group: new_group,
+          base_module_benefit: module_benefit_map.fetch(benefit.base_module_benefit_id)
+        )
+      )
     end
 
     module_benefit_map

--- a/app/views/wizard_progresses/steps/plan_comparison/_comparison.html.erb
+++ b/app/views/wizard_progresses/steps/plan_comparison/_comparison.html.erb
@@ -149,6 +149,14 @@
                                 <% if entry[:coverage_description].present? %>
                                   <p class="text-slate-600 dark:text-slate-300 leading-snug"><%= entry[:coverage_description] %></p>
                                 <% end %>
+                                <% if entry[:enhanced_by_module_names].present? %>
+                                  <p class="text-slate-600 dark:text-slate-300">
+                                    Enhanced by <%= entry[:enhanced_by_module_names].to_sentence %>
+                                  </p>
+                                <% end %>
+                                <% entry[:enhancement_notes].to_a.each do |enhancement_note| %>
+                                  <p class="text-slate-600 dark:text-slate-300"><%= enhancement_note %></p>
+                                <% end %>
                                 <% benefit_level_rules = entry[:benefit_level_limit_rules].to_a %>
                                 <% if benefit_level_rules.empty? && entry[:cost_share_text].present? %>
                                   <p class="text-slate-600 dark:text-slate-300"><%= entry[:cost_share_text] %></p>

--- a/app/views/wizard_progresses/steps/plan_creation/_module_benefits.html.erb
+++ b/app/views/wizard_progresses/steps/plan_creation/_module_benefits.html.erb
@@ -5,6 +5,10 @@
 <% available_benefits = Benefit.includes(:coverage_category).order(:name) %>
 <% existing_benefits = ModuleBenefit.where(plan_module_id: Array(plan_version&.plan_module_ids)).includes(:benefit_limit_rules, benefit: :coverage_category, plan_module: :module_group, benefit_limit_group: {}).order(:plan_module_id, :weighting, :created_at) %>
 <% grouped_benefits = existing_benefits.group_by(&:plan_module_id) %>
+<% base_benefit_candidates = existing_benefits.select { |mb| mb.base_module_benefit_id.blank? && mb.id != module_benefit.id } %>
+<% if module_benefit.benefit_id.present? %>
+  <% base_benefit_candidates = base_benefit_candidates.select { |mb| mb.benefit_id == module_benefit.benefit_id } %>
+<% end %>
 <% input_classes = "block w-full rounded-md border-0 bg-white px-3 py-2 text-base text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:ring-white/10 dark:placeholder:text-gray-500 dark:focus:ring-indigo-500" %>
 <% field_classes = lambda do |attributes, *extra_classes|
      attrs = Array(attributes)
@@ -148,6 +152,21 @@
             </div>
           </div>
 
+          <div>
+            <%= form.label :base_module_benefit_id, "Base benefit (for enhancements)", class: "text-sm font-medium text-gray-900 dark:text-gray-100" %>
+            <div class="mt-2">
+              <%= form.collection_select :base_module_benefit_id,
+                                         base_benefit_candidates,
+                                         :id,
+                                         ->(mb) { "#{mb.benefit.name} — #{mb.plan_module.module_group&.name} · #{mb.plan_module.name}" },
+                                         { include_blank: "None (base/owning benefit)" },
+                                         class: field_classes.call(:base_module_benefit),
+                                         data: { test_id: "base-module-benefit-field" } %>
+            </div>
+          </div>
+        </div>
+
+        <div class="grid gap-4 sm:grid-cols-2">
           <div>
             <%= form.label :weighting, "Weighting", class: "text-sm font-medium text-gray-900 dark:text-gray-100" %>
             <div class="mt-2">

--- a/db/migrate/20260309120000_add_base_module_benefit_to_module_benefits.rb
+++ b/db/migrate/20260309120000_add_base_module_benefit_to_module_benefits.rb
@@ -1,0 +1,9 @@
+class AddBaseModuleBenefitToModuleBenefits < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :module_benefits,
+                  :base_module_benefit,
+                  foreign_key: { to_table: :module_benefits },
+                  index: true,
+                  null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_07_190100) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_09_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -169,6 +169,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_07_190100) do
   end
 
   create_table "module_benefits", force: :cascade do |t|
+    t.bigint "base_module_benefit_id"
     t.bigint "benefit_id", null: false
     t.bigint "benefit_limit_group_id"
     t.string "coverage_description"
@@ -178,6 +179,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_07_190100) do
     t.datetime "updated_at", null: false
     t.integer "waiting_period_months"
     t.integer "weighting", default: 0, null: false
+    t.index ["base_module_benefit_id"], name: "index_module_benefits_on_base_module_benefit_id"
     t.index ["benefit_id"], name: "index_module_benefits_on_benefit_id"
     t.index ["benefit_limit_group_id"], name: "index_module_benefits_on_benefit_limit_group_id"
     t.index ["interaction_type"], name: "index_module_benefits_on_interaction_type"
@@ -333,6 +335,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_07_190100) do
   add_foreign_key "coverage_categories_plan_modules", "plan_modules"
   add_foreign_key "module_benefits", "benefit_limit_groups"
   add_foreign_key "module_benefits", "benefits"
+  add_foreign_key "module_benefits", "module_benefits", column: "base_module_benefit_id"
   add_foreign_key "module_benefits", "plan_modules"
   add_foreign_key "module_groups", "plan_versions"
   add_foreign_key "plan_geographic_cover_areas", "geographic_cover_areas"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -77,6 +77,7 @@ benefits = {
   outpatient_mental_health: Benefit.create!(name: "Outpatient mental health", coverage_category: coverage_categories[1]),
   outpatient_prescriptions: Benefit.create!(name: "Outpatient prescription drugs", coverage_category: coverage_categories[1]),
   maternity: Benefit.create!(name: "Maternity care", coverage_category: coverage_categories[2]),
+  childbirth: Benefit.create!(name: "Childbirth", coverage_category: coverage_categories[2]),
   prenatal: Benefit.create!(name: "Prenatal care", coverage_category: coverage_categories[2]),
   newborn: Benefit.create!(name: "Newborn care", coverage_category: coverage_categories[2]),
   fertility: Benefit.create!(name: "Fertility treatment", coverage_category: coverage_categories[2]),
@@ -225,6 +226,15 @@ def build_modules_for_plan!(plan:, benefits:, coverage_categories:)
     overall_limit_unit: "per_policy_year"
   )
 
+  non_hospitalisation_module = PlanModule.create!(
+    plan_version: plan_version,
+    module_group: outpatient_group,
+    name: "Non-hospitalisation Benefits",
+    is_core: false,
+    overall_limit_usd: 25_000,
+    overall_limit_unit: "per_policy_year"
+  )
+
   emergency_module = PlanModule.create!(
     plan_version: plan_version,
     module_group: emergency_group,
@@ -263,6 +273,7 @@ def build_modules_for_plan!(plan:, benefits:, coverage_categories:)
 
   inpatient_module.coverage_categories << coverage_categories[0]
   outpatient_module.coverage_categories << coverage_categories[1]
+  non_hospitalisation_module.coverage_categories << coverage_categories[2]
   emergency_module.coverage_categories << coverage_categories[5]
   maternity_module.coverage_categories << coverage_categories[2]
   dental_module.coverage_categories << coverage_categories[3]
@@ -558,6 +569,39 @@ def build_modules_for_plan!(plan:, benefits:, coverage_categories:)
     benefit: benefits[:maternity],
     coverage_description: "Prenatal, delivery, and postnatal care",
     waiting_period_months: 10
+  )
+
+  childbirth_base = ModuleBenefit.create!(
+    plan_module: maternity_module,
+    benefit: benefits[:childbirth],
+    coverage_description: "Hospital childbirth cover",
+    waiting_period_months: 10,
+    interaction_type: :append,
+    weighting: 1
+  )
+  BenefitLimitRule.create!(
+    module_benefit: childbirth_base,
+    scope: :benefit_level,
+    limit_type: :amount,
+    insurer_amount_usd: 8_000,
+    unit: "per policy year"
+  )
+
+  childbirth_enhancement = ModuleBenefit.create!(
+    plan_module: non_hospitalisation_module,
+    benefit: benefits[:childbirth],
+    coverage_description: "Additional childbirth limit applies when Non-hospitalisation Benefits is selected",
+    waiting_period_months: 8,
+    interaction_type: :enhance,
+    base_module_benefit: childbirth_base,
+    weighting: 20
+  )
+  BenefitLimitRule.create!(
+    module_benefit: childbirth_enhancement,
+    scope: :benefit_level,
+    limit_type: :amount,
+    insurer_amount_usd: 12_000,
+    unit: "per policy year"
   )
 
   ModuleBenefit.create!(

--- a/docs/domain_model.md
+++ b/docs/domain_model.md
@@ -1,6 +1,6 @@
 # Domain Model
 
-This document describes the core domain concepts used in the IPMI comparison application.
+This document describes the core domain concepts used in the IPMI comparison application.  
 It is intended as a shared reference for contributors and agents to ensure consistent naming,
 relationships, and behaviour.
 
@@ -9,9 +9,10 @@ assumptions the system relies on.
 
 ---
 
-## High-level overview
+# High-level overview
 
 The application models international health insurance products offered by insurers.
+
 At a high level:
 
 - An **Insurer** offers one or more **Plans**
@@ -21,6 +22,7 @@ At a high level:
 - **PlanModules** define coverage through **ModuleBenefits**
 - **ModuleBenefits** reference reusable **Benefits**
 - Cost-sharing (deductibles, co-payments, excesses) is modelled using **CostShares**
+- Numeric limits are modelled using **BenefitLimitRules**
 
 The system supports both:
 
@@ -29,9 +31,9 @@ The system supports both:
 
 ---
 
-## Core entities
+# Core entities
 
-### Insurer
+## Insurer
 
 Represents an insurance provider.
 
@@ -45,7 +47,7 @@ Insurers are primarily an organisational and filtering construct.
 
 ---
 
-### Plan
+## Plan
 
 Represents a named insurance product offered by an insurer.
 
@@ -59,7 +61,7 @@ A Plan acts as a stable product identity over time.
 
 ---
 
-### PlanVersion
+## PlanVersion
 
 Represents a specific version of a Plan at a given point in time.
 
@@ -79,7 +81,7 @@ across time.
 
 ---
 
-### PlanModule
+## PlanModule
 
 Represents a unit of coverage within a specific PlanVersion.
 
@@ -88,7 +90,6 @@ Key characteristics:
 - Belongs to a PlanVersion
 - Belongs to a ModuleGroup
 - Can be marked as core or optional
-- May define overall limits at the module level
 - Can be associated with multiple CoverageCategories
 - Links to Benefits via ModuleBenefits
 
@@ -97,9 +98,12 @@ A PlanModule may represent:
 - a focused area (e.g. “Outpatient”), or
 - broad coverage (e.g. a single module covering many benefit areas).
 
+PlanModules represent **where coverage originates**, but individual benefit behaviour
+is defined through ModuleBenefits.
+
 ---
 
-### ModuleGroup
+## ModuleGroup
 
 Used to group related PlanModules.
 
@@ -114,9 +118,9 @@ ModuleGroups do not define coverage themselves.
 
 ---
 
-### Benefit
+## Benefit
 
-Represents a specific insurable service or treatment type
+Represents a specific insurable service or treatment type  
 (e.g. inpatient surgery, outpatient consultations, evacuation).
 
 Key characteristics:
@@ -127,7 +131,7 @@ Key characteristics:
 
 ---
 
-### ModuleBenefit
+# ModuleBenefit
 
 Defines how a specific PlanModule covers a specific Benefit.
 
@@ -136,18 +140,138 @@ Key characteristics:
 - Belongs to a PlanModule
 - Belongs to a Benefit
 - Has many BenefitLimitRules
+- May have a CostShare
 - Stores coverage detail such as:
   - waiting periods
+  - coverage description
   - interaction type
-  - weighting / importance
-- This is where “what is actually covered” is expressed
+  - weighting / precedence
 
-ModuleBenefit is the primary source of truth for benefit-level coverage.
+ModuleBenefit is the primary source of truth for **benefit-level coverage**.
 
-**ModuleBenefit does not store numeric limits.**
+**ModuleBenefit does not store numeric limits.**  
 All numeric limits are represented via `BenefitLimitRule`.
 
-### BenefitLimitRule
+---
+
+# Base vs modifying ModuleBenefits
+
+Some modules **modify or enhance** benefits defined by another module.
+
+Example:
+
+- The **Hospital Plan** module defines a base *Childbirth* benefit.
+- The **Non-hospitalisation Benefits** module increases the childbirth limit.
+
+In this case:
+
+- the Hospital Plan ModuleBenefit is the **base benefit**
+- the Non-hospitalisation ModuleBenefit is an **enhancement**
+
+To support this behaviour:
+
+- A ModuleBenefit may optionally reference a **base ModuleBenefit**.
+- Base ModuleBenefits represent the **owning source of coverage**.
+- Enhancing ModuleBenefits modify specific attributes of the base benefit.
+
+Ownership rules:
+
+- The **owning module is always the module of the base ModuleBenefit**
+- Enhancing modules **never become the benefit owner**
+
+This distinction ensures:
+
+- correct coverage attribution
+- consistent UI behaviour
+- accurate AI analysis of plan structures.
+
+---
+
+# Interaction types
+
+ModuleBenefits may interact with other ModuleBenefits.
+
+Supported interaction types include:
+
+| Interaction | Meaning |
+|---|---|
+| append | adds additional coverage |
+| replace | replaces another benefit definition entirely |
+| enhance | modifies or improves the terms of another benefit |
+
+Enhance interactions typically change:
+
+- numeric limits
+- waiting periods
+- cost sharing
+- wording notes
+
+but do **not** change the owning module.
+
+---
+
+# Effective benefit resolution
+
+When displaying the effective coverage for a benefit:
+
+1. Locate the **base ModuleBenefit**
+2. Locate any **enhancing ModuleBenefits**
+3. Combine attributes using the override rules below.
+
+---
+
+# Field override behaviour
+
+When an enhancement exists, fields are resolved as follows.
+
+### Never overridden (always from base)
+
+These fields define benefit identity.
+
+- benefit
+- owning module
+- base_module_benefit_id
+- benefit section/category
+
+---
+
+### Inherited unless overridden
+
+These fields may be replaced by enhancements.
+
+- waiting_period_months
+- benefit_limit_rules
+- cost_share
+- inclusion / exclusion state
+- display flags
+
+---
+
+### Additive / merged
+
+These fields may combine base and enhancement information.
+
+- notes
+- explanation text
+- enhancement labels
+
+---
+
+### Coverage description rule
+
+By default:
+
+- `coverage_description` is inherited from the **base ModuleBenefit**
+
+Enhancements should not normally replace this text.
+
+Enhancements may instead provide additional explanatory notes.
+
+This prevents enhancements from incorrectly changing the perceived source of coverage.
+
+---
+
+# BenefitLimitRule
 
 Represents a numeric limit rule attached to a ModuleBenefit.
 
@@ -158,193 +282,235 @@ Key characteristics:
   - `benefit_level` for rules that apply to the whole benefit
   - `itemised` for rules that apply to a specific component (e.g. X-ray, ECG, scan)
 - Supports multiple limit types:
-  - `amount` (insurer amount in one or more of USD/GBP/EUR)
+  - `amount`
   - `as_charged`
   - `not_stated`
-- Uses insurer amount fields (`insurer_amount_*`) plus `unit` for per-use/per-period expression
-- Supports aggregate caps (`cap_insurer_amount_*` + `cap_unit`) for “up to X per year” style rules
-- Includes optional `notes` and `position` for ordering
-- Ordered by `position`, then `created_at`
 
-Worked example: Physiotherapy
+Insurer payment amounts are represented using:
+
+- `insurer_amount_usd`
+- `insurer_amount_gbp`
+- `insurer_amount_eur`
+
+Units describe how the amount applies (e.g. per session).
+
+Rules may also define aggregate caps:
+
+- `cap_insurer_amount_*`
+- `cap_unit`
+
+Rules are ordered by:
+
+1. `position`
+2. `created_at`
+
+---
+
+# Worked examples
+
+## Physiotherapy
 
 - CostShare:
   - 100% covered
-- BenefitLimitRule (`scope: benefit_level`, `limit_type: amount`):
+- BenefitLimitRule:
   - USD 50 per session, up to USD 500 per policy year
-
-Worked example: Diagnostics with itemised caps
-
-- ModuleBenefit:
-  - Benefit: Outpatient Diagnostics
-  - Coverage description: Covered
-- BenefitLimitRules (`scope: itemised`):
-  - X-ray: GBP 305 per examination
-  - ECG: USD 450 per examination
-  - Scan: USD 1,200 per examination, up to USD 2,500 per policy year
-
-Warning:
-
-- Do not add numeric limit fields outside `BenefitLimitRule`.
-- Do not add percent fields to `BenefitLimitRule`; percentages belong to `CostShare`.
 
 ---
 
-## Cost sharing (deductibles, excesses, co-payments)
+## Diagnostics with itemised caps
+
+ModuleBenefit: Outpatient diagnostics
+
+BenefitLimitRules:
+
+- X-ray: GBP 305 per examination
+- ECG: USD 450 per examination
+- Scan: USD 1,200 per examination, up to USD 2,500 per policy year
+
+---
+
+# Cost sharing
 
 Cost sharing is modelled using **CostShare** and **CostShareLink**.
 
-### CostShare
+---
 
-Represents a single cost-sharing rule.
+# CostShare
+
+Represents a cost-sharing rule.
 
 Key characteristics:
 
-- Defines amount, type (deductible, co-pay, etc.), unit, currency, and scope
-- Defines `kind`:
-  - `deductible` for plan-level and module-level cost shares
-  - `coinsurance` for benefit-level and rule-level cost shares
-- Reimbursement percentages (for example `80%` or `100% covered`) are stored here, not in `BenefitLimitRule`
-- Belongs to a polymorphic scope:
-  - a PlanVersion,
-  - a PlanModule,
-  - a ModuleBenefit, or
-  - a BenefitLimitGroup, or
-  - a BenefitLimitRule
+- Polymorphic association
+- Defines amount, percentage, unit, and application scope
 
-Display semantics:
+CostShare defines a `kind`:
 
-- PlanVersion and PlanModule cost shares are deductibles only and are not rendered inline for each benefit rule.
-- ModuleBenefit and BenefitLimitRule cost shares are rendered inline with benefit/rule output.
-- Precedence is:
-  1. BenefitLimitRule cost share (if present)
-  2. ModuleBenefit cost share (fallback)
-  3. no inline cost share
+- `deductible`
+- `coinsurance`
 
-### CostShareLink
+Percentages such as **80% coinsurance** are stored here.
+
+CostShares may attach to:
+
+- PlanVersion
+- PlanModule
+- ModuleBenefit
+- BenefitLimitGroup
+- BenefitLimitRule
+
+---
+
+# Display semantics
+
+PlanVersion and PlanModule cost shares represent **deductibles** and are **not displayed inline with each benefit**.
+
+Inline benefit display uses:
+
+1. BenefitLimitRule cost share (highest precedence)
+2. ModuleBenefit cost share
+3. no inline cost share
+
+---
+
+# CostShareLink
 
 Links one CostShare to another CostShare.
 
-Key characteristics:
+Used to model:
 
-- Connects a CostShare to another CostShare
-- Defines the relationship type (e.g. shared pool, override, dependent)
+- shared pools
+- override relationships
+- dependent cost share rules.
 
-Only one relevant CostShare should apply for a given claim context.
-
-Worked dental example:
-
-- ModuleBenefit: `Routine dental treatment`
-- BenefitLimitRules:
-  - Root treatment (cap per tooth)
-  - Extraction (cap per tooth)
-  - Surgery (cap per tooth)
-  - X-ray (cap per policy year)
-  - Anaesthesia (cap per policy year)
-- CostShare:
-  - `kind: coinsurance`
-  - `amount: 80`
-  - `unit: percent`
-  - attached per `BenefitLimitRule`
-- Result:
-  - each itemised dental rule displays `80% covered ...`
-  - a rule-level value overrides any ModuleBenefit-level coinsurance
+Only one relevant cost share should apply in a given claim context.
 
 ---
 
-## Benefit limit groups
+# Worked dental example
 
-### BenefitLimitGroup
+ModuleBenefit: Routine dental treatment
 
-Represents a shared limit that applies across multiple benefits.
+BenefitLimitRules:
+
+- Root treatment (cap per tooth)
+- Extraction (cap per tooth)
+- Surgery (cap per tooth)
+- X-ray
+- Anaesthesia
+
+CostShare:
+
+- kind: coinsurance
+- amount: 80
+- unit: percent
+
+Attached to each BenefitLimitRule.
+
+Result:
+
+Each rule displays **80% covered up to the relevant cap**.
+
+Rule-level coinsurance overrides any ModuleBenefit-level coinsurance.
+
+---
+
+# Benefit limit groups
+
+## BenefitLimitGroup
+
+Represents a shared limit across multiple benefits.
 
 Key characteristics:
 
-- Acts as a shared pool/container for related ModuleBenefits
+- Acts as a shared pool/container
 - Can be referenced by multiple ModuleBenefits
-- Has many BenefitLimitGroupRules describing the shared rule(s)
-- Supports optional wording override for insurer-specific phrasing
-
-### BenefitLimitGroupRule
-
-Represents a structured shared-limit rule attached to a BenefitLimitGroup.
-
-Key characteristics:
-
-- Belongs to a BenefitLimitGroup
-- Supports rule types:
-  - `amount` (multi-currency insurer amounts)
-  - `usage` (quantity + unit)
-  - `as_charged`
-  - `not_stated`
-- Supports period semantics:
-  - `policy_year`
-  - `calendar_year`
-  - `rolling_days`
-  - `rolling_months`
-  - `lifetime`
-- Ordered by `position`, then `created_at`
+- Has many BenefitLimitGroupRules
+- Supports optional wording overrides.
 
 ---
 
-## Plan module dependencies
+## BenefitLimitGroupRule
 
-### PlanModuleRequirement
+Defines the shared limit logic.
 
-Represents a dependency between PlanModules within a PlanVersion.
+Supported rule types:
 
-Key characteristics:
+- `amount`
+- `usage`
+- `as_charged`
+- `not_stated`
 
-- Belongs to a PlanVersion
-- Links a dependent PlanModule to a required PlanModule
-- Used to model cases where selecting one module requires another
+Supports period semantics:
+
+- policy_year
+- calendar_year
+- rolling_days
+- rolling_months
+- lifetime
+
+Ordered by `position` then `created_at`.
 
 ---
 
-## Coverage categories
+# Plan module dependencies
+
+## PlanModuleRequirement
+
+Represents a dependency between PlanModules.
+
+Used when selecting one module requires another.
+
+---
+
+# Coverage categories
 
 CoverageCategories are used as a tagging system.
 
 Key characteristics:
 
-- A PlanModule can have many CoverageCategories
-- A CoverageCategory can apply to many PlanModules
-- A Benefit belongs to a CoverageCategory
-- Categories are used for:
-  - high-level summaries
-  - filtering
-  - comparison UI
+- PlanModules may have many categories
+- Categories may apply to many modules
+- Benefits belong to a category
+
+Used for:
+
+- summaries
+- filtering
+- comparison UI.
 
 They are not a substitute for benefits or modules.
 
 ---
 
-## Geographic and residency rules
+# Geographic and residency rules
 
-### GeographicCoverArea
+## GeographicCoverArea
 
 Represents an area of cover (e.g. Worldwide, Excluding USA).
 
-Plans link to areas of cover via join models.
-
-### PlanResidencyEligibility
-
-Defines residency-based eligibility rules for a PlanVersion.
+Plans link to areas via join models.
 
 ---
 
-## Important invariants and assumptions
+## PlanResidencyEligibility
 
-- Coverage logic lives in PlanModules and ModuleBenefits, not Plans
-- PlanVersions are the unit of comparison and eligibility
-- Benefits are generic; coverage rules are contextual
-- Cost sharing must not stack implicitly
-- Naming should remain consistent with existing models
-- New domain concepts should not be introduced without revisiting this document
+Defines residency eligibility rules for a PlanVersion.
 
 ---
 
-## Explicitly out of scope
+# Important invariants
+
+- Coverage logic lives in **PlanModules and ModuleBenefits**
+- **PlanVersions** are the unit of comparison
+- Benefits are reusable and generic
+- Numeric limits must only be stored in **BenefitLimitRule**
+- Cost sharing must only be stored in **CostShare**
+- ModuleBenefit ownership must not change due to enhancements
+
+---
+
+# Explicitly out of scope
 
 The following models are not part of the insurance domain:
 
@@ -352,17 +518,15 @@ The following models are not part of the insurance domain:
 - WizardProgress
 - ActiveStorage models
 
-They should not be used to infer business or coverage logic.
+They must not be used to infer coverage logic.
 
 ---
 
-## Guidance for contributors and agents
+# Guidance for contributors and agents
 
 - Do not rename domain concepts without updating this document
-- Do not introduce parallel models that duplicate responsibility
-- When unsure where logic belongs:
-  - prefer existing models,
-  - then module–benefit relationships,
-  - and avoid introducing new abstraction layers
+- Avoid introducing duplicate models for limits or cost sharing
+- Prefer extending existing relationships rather than creating new abstractions
+- Maintain consistent terminology across plans and benefits
 
-When in doubt, simplicity and consistency take priority.
+When in doubt, **simplicity and consistency take priority**.

--- a/docs/domain_model.md
+++ b/docs/domain_model.md
@@ -171,6 +171,7 @@ In this case:
 To support this behaviour:
 
 - A ModuleBenefit may optionally reference a **base ModuleBenefit**.
+- This link is stored in `base_module_benefit_id` on `module_benefits`.
 - Base ModuleBenefits represent the **owning source of coverage**.
 - Enhancing ModuleBenefits modify specific attributes of the base benefit.
 
@@ -230,8 +231,9 @@ These fields define benefit identity.
 
 - benefit
 - owning module
-- base_module_benefit_id
+- `base_module_benefit_id` (ownership link anchor)
 - benefit section/category
+- coverage_description (unless an explicit safe override is added later)
 
 ---
 

--- a/spec/factories/module_benefits.rb
+++ b/spec/factories/module_benefits.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     benefit_limit_group { nil }
     interaction_type { :append } # append
     weighting { 0 }
+    base_module_benefit { nil }
 
     trait :with_deductible do
       after(:create) do |module_benefit|
@@ -30,6 +31,13 @@ FactoryBot.define do
       after(:create) do |module_benefit|
         create(:cost_share, scope: module_benefit, cost_share_type: :coinsurance, amount: 10, unit: :percent, per: :per_visit)
       end
+    end
+
+    trait :enhancement do
+      interaction_type { :enhance }
+      association :base_module_benefit, factory: :module_benefit
+      benefit { base_module_benefit.benefit }
+      plan_module { base_module_benefit.plan_module }
     end
   end
 end

--- a/spec/models/module_benefit_spec.rb
+++ b/spec/models/module_benefit_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe ModuleBenefit, type: :model do
       expect(enhancement).not_to be_valid
       expect(enhancement.errors[:base_module_benefit]).to include("must belong to the same plan version")
     end
+
+    it "does not allow base module benefit on non-enhance interaction types" do
+      base = create(:module_benefit)
+      non_enhance = build(:module_benefit, interaction_type: :append, benefit: base.benefit, plan_module: base.plan_module, base_module_benefit: base)
+
+      expect(non_enhance).not_to be_valid
+      expect(non_enhance.errors[:base_module_benefit]).to include("must be blank")
+    end
   end
 
   describe "coverage_or_limit_must_be_present" do

--- a/spec/models/module_benefit_spec.rb
+++ b/spec/models/module_benefit_spec.rb
@@ -6,14 +6,58 @@ RSpec.describe ModuleBenefit, type: :model do
   it { expect(module_benefit).to belong_to(:plan_module) }
   it { expect(module_benefit).to belong_to(:benefit) }
   it { expect(module_benefit).to belong_to(:benefit_limit_group).optional(true) }
+  it { expect(module_benefit).to belong_to(:base_module_benefit).class_name("ModuleBenefit").optional(true) }
+  it { expect(module_benefit).to have_many(:enhancing_module_benefits).class_name("ModuleBenefit").with_foreign_key("base_module_benefit_id").dependent(:nullify) }
   it { expect(module_benefit).to have_many(:benefit_limit_rules).dependent(:destroy) }
   it { expect(module_benefit).to have_many(:cost_shares).dependent(:destroy) }
 
-  it { should define_enum_for(:interaction_type).with_values(replace: 0, append: 1) }
+  it { should define_enum_for(:interaction_type).with_values(replace: 0, append: 1, enhance: 2) }
 
   it { expect(module_benefit).to validate_presence_of(:benefit) }
   it { expect(module_benefit).to validate_presence_of(:plan_module) }
   it { expect(module_benefit).to validate_numericality_of(:weighting).only_integer }
+
+  describe "enhancement validations" do
+    it "requires base module benefit when interaction type is enhance" do
+      enhancement = build(:module_benefit, interaction_type: :enhance, base_module_benefit: nil)
+
+      expect(enhancement).not_to be_valid
+      expect(enhancement.errors[:base_module_benefit]).to include("can't be blank")
+    end
+
+    it "does not allow a module benefit to enhance itself" do
+      module_benefit = create(:module_benefit)
+      module_benefit.base_module_benefit = module_benefit
+      module_benefit.interaction_type = :enhance
+
+      expect(module_benefit).not_to be_valid
+      expect(module_benefit.errors[:base_module_benefit]).to include("cannot reference itself")
+    end
+
+    it "requires enhancement base to have the same benefit" do
+      base = create(:module_benefit)
+      other_benefit = create(:benefit)
+      enhancement = build(:module_benefit, interaction_type: :enhance, benefit: other_benefit, base_module_benefit: base)
+
+      expect(enhancement).not_to be_valid
+      expect(enhancement.errors[:base_module_benefit]).to include("must reference the same benefit")
+    end
+
+    it "requires enhancement base to be in the same plan version" do
+      base = create(:module_benefit)
+      other_plan_module = create(:plan_module)
+      enhancement = build(
+        :module_benefit,
+        interaction_type: :enhance,
+        plan_module: other_plan_module,
+        benefit: base.benefit,
+        base_module_benefit: base
+      )
+
+      expect(enhancement).not_to be_valid
+      expect(enhancement.errors[:base_module_benefit]).to include("must belong to the same plan version")
+    end
+  end
 
   describe "coverage_or_limit_must_be_present" do
     it "is invalid without coverage description and without limit rules" do

--- a/spec/requests/wizard_progresses_spec.rb
+++ b/spec/requests/wizard_progresses_spec.rb
@@ -361,6 +361,36 @@ RSpec.describe "WizardProgresses", type: :request do
       expect(response).to have_http_status(:success)
     end
 
+    it "creates an enhancing module benefit linked to a base module benefit" do
+      plan = wizard_progress.subject
+      plan_version = plan.current_plan_version
+      module_group = create(:module_group, plan_version:)
+      hospital_module = create(:plan_module, plan_version:, module_group:, name: "Hospital Plan")
+      enhancer_module = create(:plan_module, plan_version:, module_group:, name: "Non-hospitalisation Benefits")
+      benefit = create(:benefit)
+      base_module_benefit = create(:module_benefit, plan_module: hospital_module, benefit:, coverage_description: "Base childbirth cover")
+      wizard_progress.update!(current_step: "module_benefits", step_order: 6, status: :in_progress)
+
+      expect do
+        patch wizard_progress_path(wizard_progress, format: :turbo_stream),
+              params: {
+                step_action: "add",
+                benefits: {
+                  plan_module_id: enhancer_module.id,
+                  benefit_id: benefit.id,
+                  interaction_type: "enhance",
+                  base_module_benefit_id: base_module_benefit.id,
+                  coverage_description: "Enhances childbirth limits"
+                }
+              }
+      end.to change(ModuleBenefit, :count).by(1)
+
+      created = ModuleBenefit.order(:created_at).last
+      expect(created.interaction_type).to eq("enhance")
+      expect(created.base_module_benefit).to eq(base_module_benefit)
+      expect(response).to have_http_status(:success)
+    end
+
     it "deletes a benefit limit group and cascades its module benefits" do
       plan = wizard_progress.subject
       plan_version = plan.current_plan_version

--- a/spec/services/comparison_builder_spec.rb
+++ b/spec/services/comparison_builder_spec.rb
@@ -222,5 +222,17 @@ RSpec.describe ComparisonBuilder do
       expect(entry[:plan_module_name]).to eq("Core")
       expect(entry[:waiting_period_months]).to eq(6)
     end
+
+    it "does not drop non-enhance records with a legacy base reference" do
+      entry = create(:module_benefit, plan_module: module_one, benefit: benefit_a, interaction_type: :append, coverage_description: "Legacy append")
+      legacy_base = create(:module_benefit, plan_module: module_other, benefit: benefit_a, interaction_type: :append, coverage_description: "Legacy base")
+      entry.update_column(:base_module_benefit_id, legacy_base.id)
+
+      result = described_class.new(progress).build
+      inpatient = result[:categories].find { |cat| cat[:id] == category_a.id }
+      per_selection = inpatient[:benefits].find { |b| b[:id] == benefit_a.id }[:per_selection]
+
+      expect(per_selection["sel-one"].map { |benefit_entry| benefit_entry[:module_benefit_id] }).to include(entry.id)
+    end
   end
 end

--- a/spec/services/comparison_builder_spec.rb
+++ b/spec/services/comparison_builder_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe ComparisonBuilder do
   let(:module_one) { create(:plan_module, plan_version: version_one, module_group: group_one, name: "Core") }
   let(:module_two) { create(:plan_module, plan_version: version_two, module_group: group_two, name: "Premium") }
   let(:module_other) { create(:plan_module, plan_version: version_one, module_group: group_one, name: "Optional") }
+  let(:module_enhancer) { create(:plan_module, plan_version: version_one, module_group: group_one, name: "Non-hospitalisation Benefits") }
 
   let(:progress) do
     create(
@@ -109,6 +110,117 @@ RSpec.describe ComparisonBuilder do
 
       expect(per_selection["sel-one"].size).to eq(1)
       expect(per_selection["sel-one"].first[:coverage_description]).to eq("Replace high")
+    end
+
+    it "keeps base module ownership while applying enhanced limits and notes" do
+      base = create(
+        :module_benefit,
+        plan_module: module_one,
+        benefit: benefit_a,
+        coverage_description: "Covered in hospital plan",
+        waiting_period_months: 10,
+        interaction_type: :append,
+        weighting: 1
+      )
+      create(
+        :benefit_limit_rule,
+        module_benefit: base,
+        scope: :benefit_level,
+        limit_type: :amount,
+        insurer_amount_usd: 5_000,
+        unit: "per policy year"
+      )
+      create(:cost_share, scope: base, cost_share_type: :coinsurance, amount: 80, unit: :percent, per: :per_year)
+
+      enhancement = create(
+        :module_benefit,
+        plan_module: module_enhancer,
+        benefit: benefit_a,
+        interaction_type: :enhance,
+        base_module_benefit: base,
+        coverage_description: "Enhanced for selected outpatient option",
+        waiting_period_months: 8,
+        weighting: 20
+      )
+      create(
+        :benefit_limit_rule,
+        module_benefit: enhancement,
+        scope: :benefit_level,
+        limit_type: :amount,
+        insurer_amount_usd: 8_000,
+        unit: "per policy year"
+      )
+      create(:cost_share, scope: enhancement, cost_share_type: :coinsurance, amount: 90, unit: :percent, per: :per_year)
+
+      progress.update!(
+        state: {
+          "plan_selections" => [
+            {
+              "id" => "sel-one",
+              "plan_id" => plan_one.id,
+              "module_groups" => { group_one.id.to_s => module_one.id, "#{group_one.id}-enhancer" => module_enhancer.id }
+            }
+          ]
+        }
+      )
+
+      result = described_class.new(progress).build
+      inpatient = result[:categories].find { |cat| cat[:id] == category_a.id }
+      per_selection = inpatient[:benefits].find { |b| b[:id] == benefit_a.id }[:per_selection]
+      entry = per_selection["sel-one"].find { |e| e[:module_benefit_id] == base.id }
+
+      expect(entry[:plan_module_name]).to eq("Core")
+      expect(entry[:coverage_description]).to eq("Covered in hospital plan")
+      expect(entry[:waiting_period_months]).to eq(8)
+      expect(entry[:benefit_level_limit_rules].map { |rule| rule[:insurer_amount_usd] }).to eq([ 8_000 ])
+      expect(entry[:cost_share_text]).to include("90%")
+      expect(entry[:enhanced_by_module_names]).to eq([ "Non-hospitalisation Benefits" ])
+      expect(entry[:enhancement_notes]).to include("Enhanced for selected outpatient option")
+    end
+
+    it "uses weighting between enhancements for overrides but never for ownership" do
+      base = create(:module_benefit, plan_module: module_one, benefit: benefit_a, coverage_description: "Base coverage", weighting: 1)
+      low = create(
+        :module_benefit,
+        plan_module: module_enhancer,
+        benefit: benefit_a,
+        interaction_type: :enhance,
+        base_module_benefit: base,
+        waiting_period_months: 9,
+        coverage_description: "Low enhancement",
+        weighting: 2
+      )
+      high = create(
+        :module_benefit,
+        plan_module: module_enhancer,
+        benefit: benefit_a,
+        interaction_type: :enhance,
+        base_module_benefit: base,
+        waiting_period_months: 6,
+        coverage_description: "High enhancement",
+        weighting: 12
+      )
+
+      progress.update!(
+        state: {
+          "plan_selections" => [
+            {
+              "id" => "sel-one",
+              "plan_id" => plan_one.id,
+              "module_groups" => { group_one.id.to_s => module_one.id, "#{group_one.id}-enhancer" => module_enhancer.id }
+            }
+          ]
+        }
+      )
+
+      result = described_class.new(progress).build
+      inpatient = result[:categories].find { |cat| cat[:id] == category_a.id }
+      per_selection = inpatient[:benefits].find { |b| b[:id] == benefit_a.id }[:per_selection]
+      entry = per_selection["sel-one"].find { |e| e[:module_benefit_id] == base.id }
+
+      expect([ low.id, high.id ]).not_to include(entry[:module_benefit_id])
+      expect(entry[:plan_module_name]).to eq("Core")
+      expect(entry[:waiting_period_months]).to eq(6)
     end
   end
 end

--- a/spec/services/plan_version_duplicator_spec.rb
+++ b/spec/services/plan_version_duplicator_spec.rb
@@ -65,5 +65,33 @@ RSpec.describe PlanVersionDuplicator do
       links = CostShareLink.where(cost_share_id: all_new_cost_share_ids, linked_cost_share_id: all_new_cost_share_ids)
       expect(links.count).to eq(1)
     end
+
+    it "duplicates enhancement benefits with valid base references" do
+      plan = create(:plan)
+      source_version = plan.current_plan_version
+      module_group = create(:module_group, plan_version: source_version, name: "Core", position: 1)
+      hospital_module = create(:plan_module, plan_version: source_version, module_group:, name: "Hospital")
+      enhancer_module = create(:plan_module, plan_version: source_version, module_group:, name: "Non-hospitalisation")
+      benefit = create(:benefit)
+      base = create(:module_benefit, plan_module: hospital_module, benefit:, interaction_type: :append, coverage_description: "Base")
+      create(
+        :module_benefit,
+        plan_module: enhancer_module,
+        benefit:,
+        interaction_type: :enhance,
+        base_module_benefit: base,
+        coverage_description: "Enhancement"
+      )
+
+      new_version = described_class.call(source_version)
+
+      duplicated_base = new_version.plan_modules.find_by(name: "Hospital").module_benefits.find_by(benefit:)
+      duplicated_enhancement = new_version.plan_modules.find_by(name: "Non-hospitalisation").module_benefits.find_by(benefit:)
+
+      expect(duplicated_base).to be_present
+      expect(duplicated_enhancement).to be_present
+      expect(duplicated_enhancement.interaction_type).to eq("enhance")
+      expect(duplicated_enhancement.base_module_benefit).to eq(duplicated_base)
+    end
   end
 end

--- a/spec/system/comparison_view_spec.rb
+++ b/spec/system/comparison_view_spec.rb
@@ -147,4 +147,49 @@ RSpec.describe "Plan comparison view", type: :system do
     expect(page).to have_content("Extraction: 70% coinsurance (per visit), USD 200.00 per tooth")
     expect(page).not_to have_content("Deductible")
   end
+
+  it "keeps childbirth ownership on hospital plan while applying enhancement terms" do
+    user = create(:user, email: "comparison-enhance@example.com", password: "password123")
+    progress = create(:wizard_progress, :plan_comparison, user: user, current_step: "comparison")
+
+    category = create(:coverage_category, name: "Maternity #{SecureRandom.hex(4)}", position: 1)
+    childbirth = create(:benefit, name: "Childbirth", coverage_category: category)
+
+    plan = create(:plan)
+    plan_version = plan.current_plan_version
+    group = create(:module_group, plan_version:, name: "Core")
+    hospital_module = create(:plan_module, plan_version:, module_group: group, name: "Hospital Plan")
+    enhancer_module = create(:plan_module, plan_version:, module_group: group, name: "Non-hospitalisation Benefits")
+
+    base = create(:module_benefit, plan_module: hospital_module, benefit: childbirth, coverage_description: "Hospital childbirth cover", waiting_period_months: 10)
+    create(:benefit_limit_rule, module_benefit: base, scope: :benefit_level, limit_type: :amount, insurer_amount_usd: 5_000, unit: "per policy year")
+
+    enhancement = create(
+      :module_benefit,
+      plan_module: enhancer_module,
+      benefit: childbirth,
+      interaction_type: :enhance,
+      base_module_benefit: base,
+      coverage_description: "Additional childbirth limit applies",
+      waiting_period_months: 8,
+      weighting: 20
+    )
+    create(:benefit_limit_rule, module_benefit: enhancement, scope: :benefit_level, limit_type: :amount, insurer_amount_usd: 10_000, unit: "per policy year")
+
+    progress.update!(
+      state: {
+        "plan_selections" => [
+          { "plan_id" => plan.id, "module_groups" => { group.id.to_s => hospital_module.id, "#{group.id}-enhancer" => enhancer_module.id } }
+        ]
+      }
+    )
+
+    login_as(user, scope: :user)
+    visit wizard_progress_path(progress)
+
+    expect(page).to have_content("Hospital Plan")
+    expect(page).to have_content("Hospital childbirth cover")
+    expect(page).to have_content("Enhanced by Non-hospitalisation Benefits")
+    expect(page).to have_content("USD 10000.00 per policy year")
+  end
 end


### PR DESCRIPTION
This PR introduces explicit base/enhancement modeling for ModuleBenefit so benefits can be enhanced by other modules without transferring ownership in the UI or comparison output.

It solves the childbirth-style attribution issue where replace previously made enhancements appear as if they were the source of coverage.

What Changed
1) Data model and validations
Added nullable module_benefits.base_module_benefit_id (self-referential FK).
Added ModuleBenefit self-referential associations:
belongs_to :base_module_benefit, optional: true
has_many :enhancing_module_benefits, dependent: :nullify
Added new interaction_type enum value: enhance.
Added validations:
enhance requires base_module_benefit_id
cannot enhance self
base must be a base record (not itself an enhancement)
base/enhancement must match benefit
base/enhancement must belong to same plan version
2) Admin/wizard support
Extended module benefit step to accept base_module_benefit_id.
Added a lightweight base selector in the Step 7 form:
defaults to no base for regular/base records
offers sensible candidates (base records, constrained to same benefit when selected)
3) Effective comparison merge behavior
Updated comparison resolution to treat base records as ownership/source.
Enhancements now override selected terms only (based on weighted precedence among enhancements), while ownership remains with base module.
Coverage description remains anchored to base record.
Enhancement descriptions are treated as additive notes.
UI now surfaces enhancement context (Enhanced by ...) without re-attributing ownership.
XLSX export updated to include the same enhancement context.
4) Plan version duplication support
Updated duplicator to preserve base/enhancement relationships when copying plan versions.
5) Seeds and documentation
Added seed example for childbirth enhancement:
base Childbirth on base module
enhancing Childbirth on Non-hospitalisation Benefits
linked through base_module_benefit_id
Updated domain docs to describe:
base vs enhancement semantics
ownership invariants
override/additive behavior
Behavioral Outcome
For enhanced benefits:

displayed source module stays the base module
base coverage description remains the default displayed description
enhancement can override limits/cost share/waiting period
enhancement context is shown as additional information, not ownership
Verification
bundle exec rubocop passed
bundle exec rspec passed (0 failures)
Commits
8e46e8a Add ModuleBenefit base/enhancement model and wizard support
8b00628 Resolve enhanced benefits without changing base ownership
a149f82 Add childbirth enhancement seed example and domain docs

